### PR TITLE
Fix incompatibility issue with Matomo plugin

### DIFF
--- a/wpccpl.php
+++ b/wpccpl.php
@@ -46,7 +46,11 @@ if ( ! defined( 'WPCCP_PLUGIN_BASENAME' ) ) {
 	define( 'WPCCP_PLUGIN_BASENAME', plugin_basename( WPCCP_PLUGIN_FILE ) );
 }
 // Autoloader.
-require_once 'vendor/autoload.php';
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require __DIR__ . '/vendor/autoload.php';
+} else {
+	require 'vendor/autoload.php';
+}
 
 // Bootstrap WPCCP.
 use TycheSoftwares\Wpccp\Wpccp;


### PR DESCRIPTION
See https://wordpress.org/support/topic/there-has-been-a-critical-error-on-your-website-50/

When installing the `Matomo Analytics – Ethical Stats` plugin, and then clicking in the WP Admin -> Matomo -> Reporting an error happens:

> Fatal error: Uncaught Error: Class 'TycheSoftwares\Wpccp\Wpccp' not found in wp-content/plugins/wp-content-copy-protection/wpccpl.php on line 63

It actually works using this code. It should work also without the `file_exists` check but wasn't sure if there could be maybe some cases where the directory is symlinked and then the file might not be found.

I've actually debugged for quite a while how this error happens but I'm not quite understanding the PHP logic. Especially since the Matomo plugin doesn't do a `vendor/autoload.php` but `require_once PIWIK_VENDOR_PATH . '/autoload.php';` where `VENDOR_PATH` points to the current directory. So it's not like PHP included that file already and won't include it again.

Hope you consider merging this PR as it would solve an issue for that user. If you otherwise have any other thoughts on how this error might happen or what we can do in our plugin to prevent this issue I'd be happy to take the needed steps.

Thanks